### PR TITLE
Add agent reference docs (API, models, testing, test-execution)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ backend/features/step_definitions/testing.js
 
 /act
 mongo-rs/rs_keyfile
+opencode.jsonc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# Seed-Test — Agent Instructions
+
+## Repo context
+GitHub: `adessoSE/Seed-Test` (wiki/docs at `adessoAG/Seed-Test`). Open-source BDD UI-testing platform (25★, 9↙). v1.8.1 on `master`.
+
+**API reference**: `docs/api-reference.md` (complete endpoint inventory)
+**Shared models**: `docs/shared-models.md` (all schema types + frontend copies)
+**Repo testing**: `docs/testing.md` (Vitest + Jest)
+**Test execution engine**: `docs/test-execution.md` (Cucumber/Playwright/Selenium product feature)
+
+## Architecture
+Monorepo with 3 packages: `backend` (Express/TS), `frontend` (Angular 20), `shared` (TS models).
+
+Backend is TypeScript — old `serverRouter/` removed; replaced by clean 3-layer architecture.
+
+| Shared models | — | — | imported via `@shared` alias |
+
+- **Database**: MongoDB. Default connection in `docker-compose.yml`: `mongodb://SeedAdmin:SeedTest@seedmongodb:27017`
+- **Frontend dev**: `http://localhost:4200/login`
+- **Backend API**: `http://localhost:8080/api`
+
+## Backend — routes → controllers → services
+Old `serverRouter/` replaced by clean 3-layer architecture:
+
+```
+routes/*.ts        → URL routing + request parsing
+controllers/*.ts   → HTTP handlers (call services, return JSON)
+services/*.ts      → business logic (database ops, integrations)
+```
+
+**New services:**
+- `ai.service.ts` — AI-driven test scenario generation via `@seed-test/ai-parser`, queued via `JobQueue`
+- `externalSync.service.ts` — JIRA ↔ Xray ↔ GitHub ↔ DB synchronization
+- `xray.service.ts` — Xray REST API integration
+- `feature-file.service.ts` — Gherkin feature file generation/parsing
+- `report.service.ts` — Report management
+- `test-runner.service.ts` — test execution via Cucumber
+- `import-export.service.ts` — SEED import/export
+- `block.service.ts`, `workgroup.service.ts` — new domain models
+
+**Test runners:** Playwright (`@playwright/test`) and Selenium-Webdriver both available in `backend/src/test-runners/`. Mode selected via request parameter.
+
+## Quick setup
+```bash
+# Docker (recommended — spins up mongo, backend, frontend)
+cd /c/SeedTest && docker compose up -d
+
+# Local install (Node 20/22/24)
+npm install            # root package-lock.json does nothing
+cd backend && npm install
+cd ../frontend && npm install
+# Create .env in /backend and /frontend from their .env.example files
+cd ../backend && npm run database   # creates Collections + stepTypes
+```
+
+## Key commands
+```bash
+# Backend
+npm test                     # Vitest unit tests (*.spec.ts in services/)
+npm run test-coverage        # Vitest with coverage
+npm run exec-test            # Cucumber E2E (runs .feature files in features/)
+npm run database             # initialize MongoDB collections
+npm run tsc                  # TypeScript build only
+
+# Frontend
+npm test                     # Jest unit tests
+npm run test-coverage        # Jest with coverage
+npm run build                # Angular production build
+```
+
+## Docker
+- **Production compose**: `docker-compose.yml` — uses pre-built images from Docker Hub, defaults included
+- **CI compose**: `docker-test.yml` — builds images from `./backend/Dockerfile` and `./frontend/Dockerfile`
+- **Demo image**: `docker run -p 4200:4200 -p 8080:8080 seedtest/seed-test-demo:latest`
+  - Default login: `seed@test.de` / `seedtest`
+
+## CI (GitHub Actions)
+PR → `.github/workflows/CI_Tests_and_Report.yaml`:
+1. Builds Docker stack with `docker-test.yml` (Node 20/22/24 matrix)
+2. Runs `docker exec Seed-backend npm test` and `docker exec Seed-frontend npm test`
+3. Sanity check: POST login to backend → call `/api/sanity/test/$REPO_ID/$GROUP_ID`
+4. Sends Microsoft Teams report via `actions/fullReport`
+
+Release publish → `Build_and_Publish_Images.yaml`: publishes to Docker Hub.
+
+## Environment & config
+- Backend needs `.env` in `/backend` with at least `DATABASE_URI`, `SESSION_SECRET`, `JIRA_SECRET`, `JIRA_SALT`
+  - **Also required**: `ENCRYPTION_SECRET` — 64-char hex string (used by `cryptoHelper.ts` for AES-256-GCM)
+- Frontend needs `.env` in `/frontend` with `API_SERVER` (default `http://localhost:8080/api`)
+- Docker compose embeds env vars directly in `docker-compose.yml`
+- **Default secrets in compose are not secure**: `SESSION_SECRET=secretSessionKey`, `JIRA_SECRET=secretJiraKey`, `JIRA_SALT=BJ1yJTJ7AFql`
+
+## Testing & branch conventions
+- **Primary test**: `npm test` (Vitest unit `.spec.ts` + Jest frontend) — daily use
+- **Cucumber E2E**: `npm run exec-test` — `.feature` → Cucumber → Playwright/Selenium → JSON report → docs/testing.md
+- **Branching**: Feature branches → `dev`; `master` reserved for official release tags (triggers Docker Hub build)
+
+## Style conventions (backend)
+`backend/.eslintrc.json` extends `airbnb-base` with these overrides:
+- **Tabs** for indentation (`"indent": [2, "tab"]`)
+- Single quotes, semicolons required, no `comma-dangle`
+- Curly braces **always required** (`"curly": ["error", "multi"]`)
+- `prefer-arrow-callback` enforced
+- `no-underscore-dangle`, `no-console`, `no-plusplus` all **off**
+- Lint target is **only** `src/database/` — not full backend
+
+## Files/gitignore
+Always gitignore: `.feature`, `reporting_*`, `dist/`, `node_modules/`, `.env`, `tsconfig.tsbuildinfo`, `coverage/`, `logs/`, `*.bat`, `*.sh`
+
+## SonarCloud
+Frontend-only: project key `adessoAG_Seed-Test`, test inclusions `**/*.spec.ts`, report at `frontend/coverage/lcov.info`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,179 @@
+# API Endpunkte Übersicht
+
+Alle Endpunkte sind unter `/api/` routet. Routen mit `isAuthenticated`-Middleware erfordern Login. Public (`/api/user`, `/api/playwright`, `/api/log`) sind auth-frei.
+
+## Authentifizierung
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| POST | `/api/user/register` | `{email, password}` | `{insertedId}` | Public |
+| POST | `/api/user/login` | `{email, password, stayLoggedIn?}` | `User` | Public |
+| GET | `/api/user/logout` | — | `{status: 'success'}` | Public |
+| POST | `/api/user/resetpassword` | `{email}` | `{message}` | Public |
+| PATCH | `/api/user/reset` | `{uuid, password}` | (204) | Public |
+| GET | `/api/user/` | — | `User` | Require |
+| POST | `/api/user/update/:userID` | `User` (partial) | `User` | Require |
+| DELETE | `/api/user/` | — | `{message}` | Require |
+| GET | `/api/user/callback`?code= | — | `User` | Public |
+| POST | `/api/user/mergeGithub` | `{userId, login, id}` | `{status}` | Require |
+
+## Repositories
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| GET | `/api/repository/` | — | `RepositoryContainer[]` | Require |
+| POST | `/api/repository/` | `{name}` | `{insertedId}` | Require |
+| GET | `/api/repository/settings/:repo_id` | — | `settings` object | Require |
+| GET | `/api/repository/aiconfig/:repo_id` | — | `AiConfig` | Require |
+| PUT | `/api/repository/settings/:repo_id` | `{repoName?, settings?, aiConfig?}` | `Repository` | Require |
+| PUT | `/api/repository/owner/:repo_id` | `{email}` | `{message}` | Require |
+| DELETE | `/api/repository/:repo_id` | — | `Result` | Require |
+
+## Stories
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| GET | `/api/story/` | query: `source`, `id` | `Story[]` | Require |
+| POST | `/api/story/` | `{title, description, _id: repoId}` | `{_id}` | Require |
+| GET | `/api/story/:_id` | — | `Story` | Require |
+| PUT | `/api/story/:_id` | `Story` | `Story` | Require |
+| DELETE | `/api/story/:repo_id/:_id` | — | `{message}` | Require |
+| PUT | `/api/story/list/:repo_id` | `string[]` (IDs) | `{message}` | Require |
+| POST | `/api/story/:story_id` | `{name}` | `Scenario` | Require |
+| PUT | `/api/story/:story_id/:_id` | `Scenario` | `Scenario` | Require |
+| GET | `/api/story/:story_id/:_id` | — | `Scenario` | Require |
+| DELETE | `/api/scenario/:story_id/:_id` | — | `{message}` | Require |
+| PATCH | `/api/story/:story_id` | `Scenario[]` | `{message}` | Require |
+| GET | `/api/story/download/story/:_id` | — | Binary `.feature` | Require |
+| GET | `/api/story/download/project/:repo_id` | query: `version_id` | Binary `.zip` | Require |
+| GET | `/api/story/download/export/:repo_id` | — | Binary `.zip` | Require |
+| POST/PUT | `/api/story/upload/import/` | multer file + query: `repo_id, projectName, importMode` | `{message}` | Require |
+| POST | `/api/story/specialCommands/resolve` | `{command}` | `{resolved}` | Require |
+| POST | `/api/story/oneDriver/:storyID` | `{oneDriver}` | `Result` | Require |
+| GET | `/api/story/issueKey/:issue_key` | — | `Story` | Require |
+| POST | `/api/story/:story_id/generate-scenarios` | `{aiConfig: AiConfig}` | `{message: 'queued'}` | Require |
+| GET | `/api/story/:story_id/generate-scenarios/status` | — | SSE event stream (202) | Require |
+
+## Groups
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| GET | `/api/group/:repo_id` | — | `Group[]` | Require |
+| POST | `/api/group/:repo_id` | `{name, member_stories?, sequence?, xrayTestSet?}` | `{group_id}` | Require |
+| PUT | `/api/group/:repo_id/:group_id` | `Group` | `Group` | Require |
+| DELETE | `/api/group/:repo_id/:group_id` | — | `{message}` | Require |
+| POST | `/api/group/:repo_id/:group_id/:story_id` | — | `{message}` | Require |
+| DELETE | `/api/group/:repo_id/:group_id/:story_id` | — | `{message}` | Require |
+| PUT | `/api/group/:repo_id` | `Group[]` | `{message}` | Require |
+
+## Blocks
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| POST | `/api/block/` | `Block` | `{insertedId}` | Require |
+| GET | `/api/block/getBlocks/:repoId` | — | `Block[]` | Require |
+| PUT | `/api/block/:blockId` | `Block` | `Block` | Require |
+| DELETE | `/api/block/:blockId` | — | `{message}` or 404 | Require |
+
+## Background
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| PUT | `/api/background/:storyID` | `Background` | `{Background}` | Require |
+| DELETE | `/api/background/:storyID` | — | `{}` | Require |
+
+## Workgroups (Team-Mitglieder)
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| GET | `/api/workgroup/:id/members` | — | `{owner, members}` | Require |
+| POST | `/api/workgroup/:id/members` | `{email, canEdit?}` | `{message}` | Require |
+| PUT | `/api/workgroup/:id/members` | `{email, canEdit}` | `{message}` | Require |
+| DELETE | `/api/workgroup/:id/members` | `{email}` | `{message}` | Require |
+
+## Files (Upload)
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| POST | `/api/files/:repoId` | multer file (binary) | `FileElement` | Require |
+| GET | `/api/files/:repoId` | — | `FileElement[]` | Require |
+| DELETE | `/api/files/:fileId` | — | `{message}` | Require |
+
+## Reports
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| GET | `/api/report/:reportId` | — | `Report` doc | Require |
+| GET | `/api/report/regenerate/:reportName` | — | `{htmlFile, reportId}` | Require |
+| GET | `/api/report/history/:storyId` | — | `ReportContainer` | Require |
+| DELETE | `/api/report/:reportId` | — | `{message}` | Require |
+| PUT | `/api/report/save/:reportId` | — | `{message}` | Require |
+| PUT | `/api/report/unsave/:reportId` | — | `{message}` | Require |
+
+## Test Execution
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| POST | `/api/execute/Feature/:issueID` | `{repositoryId}` | `{htmlFile, reportId, report}` | Require |
+| POST | `/api/execute/Scenario/:issueID/:scenarioId` | `{repositoryId}` | `{htmlFile, reportId, report}` | Require |
+| POST | `/api/execute/Group/:repoID/:groupID` | `{repositoryId, repository}` | `{htmlFile, reportId, report}` | Require |
+| POST | `/api/execute/TempGroup` | `{group, repositoryId}` | `{htmlFile, reportId, report}` | Require |
+
+### Test Execution Request Body
+
+```typescript
+interface ExecuteTestRequest {
+    repositoryId?: string;
+    repoId?: string;       // legacy
+    testRunner?: 'seleniumWebdriver' | 'playwright';  // mode selector
+    name?: string;         // for group directory
+    body: {
+        browser: string;
+        waitTime: number;
+        daisyAutoLogout: boolean;
+        emulator?: string;
+        windowSize?: { height: number; width: number };
+        [key: string]: any;
+    };
+    user?: User;
+}
+```
+
+## Script (automatisierte Ausführung ohne Browser)
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| POST | `/api/script/Group` | `{repoID, groupID, repository?, stayLoggedIn?, email, password}` | `handleReportResult` JSON | Passport+Body |
+| POST | `/api/script/Feature/:issueID` | `{issueID, repositoryId, stayLoggedIn?, email, password}` | `handleReportResult` JSON | Passport+Body |
+
+> `script` Route verwendet eigenes Auth-Middleware (`authenticateAndProceed`) — Body enthält Login-Credentials direkt.
+
+## External Integrations
+
+### Jira
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| POST | `/api/jira/link` | `{jiraAccountName, jiraPassword, jiraHost, jiraAuthMethod?}` | `{message}` | Require |
+| DELETE | `/api/jira/disconnect` | — | `{message}` | Require |
+| POST | `/api/jira/login` | `{jiraAccountName, jiraPassword, jiraServer, AuthMethod}` | `{sessionCookie}` | Require |
+| PUT | `/api/jira/xray-status` | `{testRunId, stepId, status}` | Xray API response | Require |
+
+### GitHub
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| POST | `/api/github/submitIssue` | `{title, body, ...}` | GitHub Issue JSON | Require |
+| DELETE | `/api/github/disconnectGithub` | — | `{message}` | Require |
+
+## System
+
+| | Endpoint | Body | Response | Auth |
+|---|---------|------|----------|------|
+| GET | `/api/health` | — | `OK` | Public |
+| GET | `/api` | — | HTML page | Public |
+| POST | `/api/log` | `{message, additional?}` | `{message: 'logged'}` | Public |
+| GET | `/api/playwright/devices` | — | `PlaywrightDevices` | Public |
+| GET | `/api/playwright/device-names` | — | `string[]` | Public |
+| GET | `/api/stepTypes` | — | `StepType[]` | Require |
+| POST | `/api/sanity/test/:repoID/:groupID` | — | Text notification | Require |

--- a/docs/shared-models.md
+++ b/docs/shared-models.md
@@ -1,0 +1,273 @@
+# Shared Models (TypeScript)
+
+Die Modelle in `shared/src/models/` werden vom Backend und Frontend genutzt via `import { Foo } from '@shared/models/Foo'`.
+
+## Core Domain Models
+
+### `Story`
+```typescript
+interface Story {
+    _id?: any;
+    issue_number?: number | string;
+    story_id: number;
+    storySource: string;
+    background: Background;
+    scenarios: Scenario[];
+    oneDriver?: boolean;
+    title: string;
+    body: string;
+    sourceSteps?: string;
+    repo_type: string;
+    state: string;
+    assignee: string;
+    assignee_avatar_url: string;
+    lastTestPassed?: boolean;
+    preConditions?: { preConditionKey: string; preConditionName: string; testSet: string[] }[];
+    host?: string;
+    aiSuggestion?: object;
+}
+```
+
+### `Scenario`
+```typescript
+interface Scenario {
+    scenario_id: number;
+    name: string;
+    stepDefinitions: StepDefinition;
+    comment: string;
+    lastTestPassed?: boolean;
+    saved?: boolean;
+    stepWaitTime?: number;
+    browser?: string;
+    emulator?: string;
+    hasRefBlock?: boolean;
+    width?: number;
+    height?: number;
+    testRunSteps?: { testRunId: number; testRunStepId: number; testExecKey: string }[];
+    testKey?: string;
+    multipleScenarios?: MultipleScenario[];
+}
+```
+
+### `Background`
+```typescript
+interface Background {
+    name?: string;
+    stepDefinitions: StepDefinitionBackground;
+    saved?: boolean;
+}
+```
+
+### `Group`
+```typescript
+interface Group {
+    _id?: any;
+    name: string;
+    member_stories: any[];
+    isSequential: boolean;
+    xrayTestSet?: boolean;
+}
+```
+
+### `Block`
+```typescript
+interface Block {
+    _id?: any;
+    owner?: any;
+    name?: string;
+    stepDefinitions: StepDefinition;
+    repositoryId?: any;
+    repository?: string;
+    source?: string;
+    isBackground?: boolean;
+    usedAsReference?: boolean;
+}
+```
+
+### `StepDefinition`
+```typescript
+interface StepDefinition {
+    given: StepType[];
+    when: StepType[];
+    then: StepType[];
+    example?: StepType[];
+}
+```
+
+### `StepType`
+```typescript
+interface StepType {
+    _blockReferenceId?: string;
+    _id?: string;
+    id: number;
+    pre: string;
+    mid: string;
+    post?: string;
+    selection?: string[];
+    selectionValue?: number;
+    stepType: string;
+    type: string;
+    values: string[];
+    isExample?: boolean[];
+    outdated?: boolean;
+    checked?: boolean;
+    deactivated?: boolean;
+    blockStepExpanded?: boolean;
+    origin?: string;
+}
+```
+
+### `FileElement`
+```typescript
+class FileElement {
+    _id?: any;
+    uploadDate?: string | Date;
+    filename?: string;
+}
+```
+
+### `MultipleScenario`
+```typescript
+interface MultipleScenario {
+    values: string[];
+    checked?: boolean;
+    deactivated?: boolean;
+}
+```
+
+## Aggregation / Container Models
+
+### `Repository`
+```typescript
+interface Repository {
+    _id?: any;
+    owner: any;
+    repoName: string;
+    stories: any[];
+    repoType: 'db' | 'github' | 'jira';
+    customBlocks?: any[];
+    groups: Group[];
+    settings?: { stepWaitTime?: number; reportComment?: boolean; browser?: string; testRunner?: string; emulator?: string; width?: number; height?: number; activated?: boolean };
+    aiConfig?: AiConfig;
+    gitOwner?: string;
+}
+```
+
+### `AiConfig`
+```typescript
+interface AiConfig {
+    textPreparation: AiProviderConfig;
+    jsonConversion: AiProviderConfig;
+}
+
+interface AiProviderConfig {
+    provider: 'custom';
+    name: 'local' | 'cloud';
+    modelName: string;
+    baseURL: string;
+    apiKey?: string;
+}
+```
+
+### `User`
+```typescript
+interface User {
+    _id?: any;
+    email: string;
+    password?: string;
+    transitioned?: boolean;
+    github: { githubToken: string; login: string; id: number; githubRepo?: string };
+    jira?: { AccountName: string; Password: { $binary: { base64: string; subType: string } }; Password_Nonce: { $binary: { base64: string; subType: string } }; Password_Tag: { $binary: { base64: string; subType: string } }; Host: string; AuthMethod: string };
+}
+```
+
+## Report / Status Models
+
+### `ReportContainer`
+```typescript
+interface ReportContainer {
+    storyReports: StoryReport[];
+    scenarioReports: ScenarioReport[];
+    groupReports: GroupReport[];
+}
+```
+
+### `StoryReport`
+```typescript
+interface StoryReport {
+    _id: any;
+    reportName: string;
+    reportTime: number;
+    reportOptions: any;
+    storyId: any;
+    mode: string;
+    scenarioId?: any;
+    isSaved?: boolean;
+    overallTestStatus: boolean;
+    storyStepResults: StepResults;
+    scenarioStatuses: ScenarioStatus[];
+}
+```
+
+### `ScenarioReport`
+```typescript
+interface ScenarioReport {
+    _id?: any;
+    reportName: string;
+    reportTime: number;
+    reportOptions: any;
+    storyId: any;
+    mode: string;
+    scenarioId: any;
+    overallTestStatus: boolean;
+    isSaved?: boolean;
+    scenarioStatuses: ScenarioStatus;
+}
+```
+
+### `GroupReport`
+```typescript
+interface GroupReport {
+    _id?: any;
+    reportName: string;
+    reportTime: number;
+    reportOptions: any;
+    mode: string;
+    isSaved?: boolean;
+    overallTestStatus: boolean;
+    storyStatuses: StoryStatus[];
+    groupStepResults: StepResults;
+}
+```
+
+### `StepResults`
+```typescript
+interface StepResults {
+    passedSteps: number;
+    failedSteps: number;
+    skippedSteps: number;
+}
+```
+
+### `ScenarioStatus`
+```typescript
+interface ScenarioStatus {
+    scenarioId: any;
+    status: boolean;
+    stepResults: StepResults;
+}
+```
+
+### `StoryStatus`
+```typescript
+interface StoryStatus {
+    storyId: any;
+    status: boolean;
+    storyStepResults: StepResults;
+    scenarioStatuses: ScenarioStatus[];
+}
+```
+
+## Frontend-local models
+
+Im Frontend (`frontend/src/app/model/`) gibt es **dieselben Models** als lokale Kopien (nicht referenziell identisch zu `shared/`). Sie werden direkt in Template-Typen verwendet. Die Felder decken sich mit den shared-Modellen.

--- a/docs/test-execution.md
+++ b/docs/test-execution.md
@@ -1,0 +1,225 @@
+# Test Execution Engine — Produktfeature
+
+Seed-Test kann **beliebige Web-Apps via Low-Code testen**. Der Nutzer erstellt Scenarios mit vordefinierten Steps, die in echte Browser-Automatisierung (Playwright oder Selenium) übersetzt werden.
+
+## Architektur
+
+```
+[User erstellt Story] → Seed-Test generiert [.feature] Cucumber-Datei
+                        ↓
+                  [User führt Test aus] → Seed-Test API → Cucumber Runtime
+                        ↓
+                  [Playwright od. Selenium] → Browser steuern die Ziel-App
+                        ↓
+                  [JSON Report] → Seed-Test Report-Service
+```
+
+## Konfiguration des Nutzers
+
+Jedes Repository (Project) hat Settings für den Test-Runner:
+
+| Setting | Type | Default | Beschreibung |
+|---------|------|---------|-------------|
+| `browser` | string | chromium | Chromium, Firefox, WebKit, MicrosoftEdge |
+| `waitTime` | number | 0 | Millisekunden Pause pro Step |
+| `emulator` | string | — | Playwright Device Descriptor (z.B. "iPhone 12") |
+| `width` / `height` | number | — | Fenstergröße (1920x1080 Standard) |
+| `daisyAutoLogout` | boolean | false | Daisy-System: Auto-Logout aktivieren |
+| `oneDriver` | boolean | false | Einen Browser über mehrere Scenarios teilen |
+
+## Test-Erstellung im Tool
+
+Der Nutzer erstellt im Seed-Test-Frontend:
+1. **Story** → Name, Beschreibung, Repository
+2. **Background** → Gemeinsame Setup-Schritte (muss nicht existieren)
+3. **Scenarios** → Einzelne Tests mit Given/When/Then Steps
+4. **Steps** mit `StepType`-Referenzen → vordefinierte Aktionen (Button klick, Text einfügen etc.)
+5. **Block-References** (`_blockReferenceId`) → wiederverwendbare Step-Gruppen
+
+## Feature-Generierung
+
+`feature-file.service.ts` wandelt Seeds Story → Gherkin Feature File:
+
+```gherkin
+Feature: Story Title
+
+Background:
+  When Step pre 'value' mid post
+
+Scenario: Scenario Name
+  Given ... steps ...
+  When ... steps ...
+  Then ... steps ...
+  Examples:
+  | value1 | value2 | value3 |
+
+Scenario: Another Name
+  ... (optional Outline mit Examples)
+```
+
+- Step-Struktur: `pre 'value' mid post` + optional `value1 | value2 | value3`
+- Block-References werden vor dem Schreiben expandiert (rekursiv)
+- Feature-Dateien landen in `backend/features/`, werden gitignored
+- Ggf. neu generiert bevor Test läuft (falls veraltet/fehlt)
+
+## API: Test ausführen
+
+4 Endpunkte triggern Testausführung:
+
+| Endpoint | Beschreibung |
+|----------|-------------|
+| `POST /api/execute/Feature/:issueID` | Alle Scenarios einer Story |
+| `POST /api/execute/Scenario/:issueID/:scenarioId` | Einzelnes Scenario |
+| `POST /api/execute/Group/:repoID/:groupID` | Alle Stories einer Gruppe |
+| `POST /api/execute/TempGroup` | Temporäre Gruppe (Pre-Conditions) |
+
+Request Body:
+```typescript
+{
+    repositoryId: string,
+    testRunner: 'seleniumWebdriver' | 'playwright',  // default: selenium
+    body: {
+        browser: string,           // chromium/firefox/webkit/MicrosoftEdge
+        waitTime: number,           // ms zwischen Steps
+        daisyAutoLogout: boolean,
+        emulator?: string,          // Playwright device descriptor
+        windowSize?: { height, width }
+    }
+}
+```
+
+## Step Definitionen — das Herz
+
+Das Tool enthält **32 vordefinierte Low-Code Steps**, die sowohl für **Playwright** als auch **Selenium** laufen (runner-agnostisch):
+
+### Given (8 Steps)
+| Step Pattern | Funktion |
+|-------------|----------|
+| `As a {string}` | Rolle/User speichern |
+| `I am on the website: {string}` | Zur URL navigieren |
+| `I add a cookie with the name {string} and value {string}` | Cookie setzen |
+| `I remove a cookie with the name {string}` | Cookie löschen |
+| `I add a session-storage with the name {string} and value {string}` | sessionStorage setzen |
+| `I remove a session-storage with the name {string}` | sessionStorage löschen |
+| `I take a screenshot` | Page-Screenshot an Report anhängen |
+| `I take a screenshot. Optionally: Focus the page on the element {string}` | Screenshot + Scroll zum Element |
+
+### When (14 Steps)
+| Step Pattern | Funktion |
+|-------------|----------|
+| `I go to the website: {string}` | Zur URL navigieren |
+| `I click the button: {string}` | Button finden & klicken (mit Download-Polling) |
+| `The site should wait for {string} milliseconds` | Pause + 1s Buffer |
+| `I insert {string} into the field {string}` | Input/Textarea finden & füllen |
+| `I select {string} from the selection {string}` | Radio-Button wählen |
+| `I select the option {string} from the drop-down-menue {string}` | Dropdown öffnen & Option wählen |
+| `I select the option {string}` | Option aus aktivem Dropdown wählen |
+| `I hover over the element {string} and select the option {string}` | Hover → Menü-Auswahl |
+| `I select from the {string} multiple selection, the values {string}{string}{string}` | Multi-Select (unvollständig) |
+| `I check the box {string}` | Checkbox setzen |
+| `Switch to the newly opened tab` | Zum neuesten Tab wechseln |
+| `Switch to the tab number {string}` | Zu konkretem Tab wechseln |
+| `I switch to the next tab` | Nächster Tab |
+| `I want to upload the file from this path: {string} into this uploadfield: {string}` | Datei-Upload |
+
+### Then (10 Steps)
+| Step Pattern | Funktion |
+|-------------|----------|
+| `So I will be navigated to the website: {string}` | URL-Assertion |
+| `So I can see the text {string} in the textbox: {string}` | Input-Value-Assertion |
+| `So I can see the text: {string}` | Text-Assertion (mit Regex-Support `{Regex:...}`) |
+| `So I can't see text in the textbox: {string}` | Negierte Text-Assertion |
+| `So a file with the name {string} is downloaded in this Directory {string}` | Datei-Download-Assertion |
+| `So the picture {string} has the name {string}` | Bild-Upload-Assertion |
+| `So I can't see the text: {string}` | Negierte Text-Assertion |
+| `So the checkbox {string} is set to {string}` | Checkbox-Status-Assertion |
+| `So on element {string} the css property {string} is {string}` | CSS-Property-Assertion (inkl. Farben) |
+| `So the element {string} has the tool-tip {string}` | Tooltip-Assertion |
+
+## Locating Strategy
+
+Jeder Step versucht **mehrere Locator-Strategien sequentiell**, bis einer erfolgreich ist.
+
+### Playwright (Primary)
+1. **Preferred locators** → `getByRole()`, `getByLabel()`, `getByText()`, `locator()` (CSS)  
+2. **XPath locators** → `locator('xpath=...')`  
+3. Wenn alle fehlschlagen → Fehler mit Liste aller versuchten Locators
+
+Die Locator-Strategie ist für jede Aktion (click, fill, check, hover, ...) speziell optimiert. Beispiel "button click":
+`getByRole("button", name)`, `getByText`, `getByLabel`, `#${id}`, `[id*=...]`, dann 8 XPath-Varianten.
+
+### Selenium (Legacy)
+Nur XPath-basiert mit string-Interpolation und `Promise.any()` über Locator-Array.
+
+## Special Features
+
+### `@*` Wildcard Expansion
+Steps unterstützen Selenium's `@*=`, `contains(@*, ...)` Wildcards. Playwright expandiert diese automatisch in eine Liste bekannter Attribute (`id`, `name`, `class`, `data-testid`, `aria-label`, `title`, ...) basierend auf Element-Typ.
+
+### `Apply Special Commands`
+`text` Parameter werden durch `applySpecialCommands()` gefiltert — unterstützt Commands wie `{Enter}`, `{Tab}`, `{Backspace}` etc. (definiert in `helpers/specialCommandParser.ts`).
+
+### `Regex` Assertions
+Text-Assertions unterstützen `{Regex:pattern}` Syntax um regular Expressions in Assertions zu verwenden.
+
+## `World` Klassen
+
+Jeder Step hat Zugriff auf `this` vom Typ (abhängig vom gewählten Runner):
+
+### PlaywrightWorld (`PlaywrightWorld`)
+- Browser-Session: `chromium`, `firefox`, `webkit`, `MicrosoftEdge`
+- Download-Verzeichnis: `C:\Users\Public\seed_Downloads\` / `/home/public/Downloads/`
+- Upload-Verzeichnis: `C:\Users\Public\SeedTmp\` / `/home/public/SeedTmp\`
+- `download.suggestedFilename()` für Download-Capture
+- Tab-Management über `context.pages()` + `bringToFront()`
+
+### SeleniumWebdriverWorld (`SeleniumWebdriverWorld`)
+- WebDriver-Session mit `By.xpath()`
+- Download-Verifizierung über `fs.promises.access()` + `fs.promises.rename()`
+- Tab-Management über `driver.getAllWindowHandles()` + `driver.switchTo().window()`
+
+### Shared Features
+- **`oneDriver`-Modus**: Browser-Session über mehrere Scenarios teilen (geteilte Instances)
+- **Screenshot on fail**: Auto-Screenshot + Report-Anhang bei Step-Fehler
+- **Emulator-Modus**: Playwright Device Descriptors (z.B. "iPhone 12") — nur Chromium-basierte Browser
+
+## Reporting
+
+| Artifact | Location | Format |
+|----------|----------|--------|
+| Roh-JSON Report | `backend/features/reporting_<timestamp>.json` | Cucumber JSON |
+| HTML Report | `backend/features/reporting_<timestamp>.html` | HTML |
+| Screenshot (fail) | Download-Verzeichnis | PNG |
+| Screenshot (manual) | Download-Verzeichnis | `manual-{timestamp}.png` |
+
+- Reports werden nach `REPORT_DELETION_TIME` Minuten automatisch gelöscht
+- Report-Service speichert Reports in DB (`reportId` für API-Rückgabe)
+- HTML-Report: gruppierte JSON → Cucumber-Reporter → `cucumber-html-reporter`
+
+## Technische Details
+
+### Cucumber Runtime
+- `@cucumber/cucumber` v12
+- Dynamisch geladen: `import('@cucumber/cucumber/api')`
+- Support Code StepDefs werden pro Runner **gecached** (Wiederverwendung zwischen Test-Calls)
+- Tags für single-Scenario-Selection: `@<storyID>_<scenarioId>`
+
+### Timeout-Strategie
+- Playwright: 30s global, 15s searchTimeout, 5s/10s context/page-level
+- Selenium: 60s global default
+- `page.setDefaultTimeout(5000)` + `page.setDefaultNavigationTimeout(10000)`
+
+### Test-Modes
+- `scenario`: Einzelnes Scenario einer Story
+- `feature`: Alle Scenarios einer Story  
+- `group`: Alle Stories einer Gruppe
+
+### Caching
+`cachedSupportCode` hält Playwright- und Selenium-StepDefs im Speicher zwischen. `loadSupport()` vom Cucumber-Runner wird nur beim **ersten** Test pro Runner aufgerufen. Folge-Tests verwenden die gecachte Instance → spart Startzeit.
+
+### Frontend-Support
+Die UI zeigt:
+- Live-Fortschritt pro Scenario (Loading/Running/Done)
+- Download-Link für den HTML Report
+- Report-Status in der Story-Ansicht
+- Pre-Conditions Editor für Gruppen-Tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,68 @@
+# Repo-Qualitätssicherung — Tests
+
+Seed-Test ist eine Low-Code-WebApp zum Generieren von Browser-Automation-Tests. Diese Seite dokumentiert, wie **das Tool selbst** getestet wird.
+
+## Tests ausführen
+
+```bash
+# Backend — Vitest Unit-Tests
+cd backend && npm test              # alle Tests
+npm run test-coverage               # mit Coverage-Report
+
+# Frontend — Jest Unit-Tests
+cd frontend && npm test             # alle Tests
+npm run test-coverage               # mit Coverage-Report
+
+# Zusammen (wird auch in CI verwendet):
+npm test (in backend/ und frontend/ einzeln)
+```
+
+## Backend (Vitest)
+
+- `*.spec.ts` Dateien liegen **neben der zu testenden Logik** in `backend/src/services/`
+- Vitest ist global konfiguriert: `describe`, `it`, `expect` benötigen keine Imports
+- `@shared` alias → `backend/src/shared/src/` (konfiguriert in `vitest.config.ts`)
+- Target ist `node`, nicht DOM
+- Konfig: `backend/vitest.config.ts` mit `@shared` Path-Alias
+
+```typescript
+// Beispiel: backend/src/services/*.spec.ts
+import { describe, it, expect } from 'vitest';
+import { someService } from './some.service';
+
+describe('Service', () => {
+  it('sollte X tun', () => {
+    expect(someService()).toBe(expected);
+  });
+});
+```
+
+## Frontend (Jest)
+
+- Jest mit `jest-preset-angular` für Angular 20
+- läuft in `jsdom` (nicht echte Browser)
+- Benötigt `jest-canvas-mock` Polyfill
+- Konfig: `frontend/jest.config.ts`
+
+```bash
+# Einzelen Test:
+npm test -- --testPathPattern=service-name.spec.ts
+
+# Watch mode:
+npm test -- --watch
+```
+
+## CI-Tests
+
+GitHub Actions CI (`CI_Tests_and_Report.yaml`) läuft:
+1. Docker Stack Build mit `docker-test.yml` (Node 20/22/24 Matrix)
+2. `docker exec Seed-backend npm test`
+3. `docker exec Seed-frontend npm test`
+4. Sanity Check: POST login → `/api/sanity/test/$REPO_ID/$GROUP_ID`
+5. Teams-Report via Microsoft Teams Webhook
+
+## SonarCloud
+
+- Frontend-Only: Project key `adessoAG_Seed-Test`
+- Test Inclusions: `**/*.spec.ts`
+- Report: `frontend/coverage/lcov.info`


### PR DESCRIPTION
Docs f\u00fcr Agenten zur Repo-Navigation:\n\n- **api-reference.md** \u2014 71 API-Endpunkte mit Body/Response-Types\n- **shared-models.md** \u2014 21 TypeScript Models + Frontend-Kopien\n- **testing.md** \u2014 Vitest/Jest Setup (Repo-Qualit\u00e4tssicherung)\n- **test-execution.md** \u2014 Cucumber/Playwright/Selenium (Produktfeature)\n- **AGENTS.md** \u2014 verlinkt alle Docs + Branching/Release-Regeln\n\nBranching: Feature Branches \u2192 dev, master nur f\u00fcr Releases.